### PR TITLE
Update Vercel dependency to version 41.7.8 in package.json and packag…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "mongoose": "^8.12.2",
         "multer": "^1.4.5-lts.2",
         "qrcode": "^1.5.4",
-        "vercel": "^41.7.6"
+        "vercel": "^41.7.8"
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
@@ -804,9 +804,9 @@
       }
     },
     "node_modules/@vercel/remix-builder": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.4.5.tgz",
-      "integrity": "sha512-fwUNSnAdMNFP9FSk9ZZwLg2uduqRRFaZYX+7GCsZfoRiJzDoEUM+22rhCP3N2A7Z4m07a+Wg1qCuKTeMijf44g==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@vercel/remix-builder/-/remix-builder-5.4.6.tgz",
+      "integrity": "sha512-Yy51eFlORcPweYgVW81s7MhSH9MWl67QetrRB1J2wkDnoKZ3nE8t403oavEAbZPL/z0JQG1RHYRjnUfYCXtTKQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/error-utils": "2.0.3",
@@ -4421,9 +4421,9 @@
       }
     },
     "node_modules/vercel": {
-      "version": "41.7.6",
-      "resolved": "https://registry.npmjs.org/vercel/-/vercel-41.7.6.tgz",
-      "integrity": "sha512-jz+9T0TK5otqM2VMeIEiix4HjtQF/RYsdFjABWXOSCta0Fc1/+ReWAv+X8AolvJCak5kJ4czvfgwD+tBBiI54w==",
+      "version": "41.7.8",
+      "resolved": "https://registry.npmjs.org/vercel/-/vercel-41.7.8.tgz",
+      "integrity": "sha512-itUz44eMHFxjE/iSNIlQzyypQ2LfnD/LzTg4ptL+uq7bT3zjGZ+MCEUUy9y4XkRV4zMBKvKzDeXVXajKLn71sA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@vercel/build-utils": "10.5.1",
@@ -4434,7 +4434,7 @@
         "@vercel/node": "5.1.16",
         "@vercel/python": "4.7.2",
         "@vercel/redwood": "2.3.1",
-        "@vercel/remix-builder": "5.4.5",
+        "@vercel/remix-builder": "5.4.6",
         "@vercel/ruby": "2.2.0",
         "@vercel/static-build": "2.7.7",
         "chokidar": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mongoose": "^8.12.2",
     "multer": "^1.4.5-lts.2",
     "qrcode": "^1.5.4",
-    "vercel": "^41.7.6"
+    "vercel": "^41.7.8"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"


### PR DESCRIPTION
…e-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "vercel" dependency to the latest version for improved stability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->